### PR TITLE
Add memory mapping

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,12 @@
 name = "SDFReader"
 uuid = "bd0b56a1-724b-4db5-9cfb-6781c02e0e49"
 authors = ["Sebastian Micluța-Câmpeanu <m.c.sebastian95@gmail.com>"]
-version = "0.4.1"
+version = "0.5.0"
 
 [deps]
 DiskArrays = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
+Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
+TiledIteration = "06e1c1a7-607b-532d-9fad-de7d9aa2abac"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
@@ -14,8 +16,8 @@ julia = "1.5, 1.6"
 
 [extras]
 LRUCache = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
-Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/src/SDFReader.jl
+++ b/src/SDFReader.jl
@@ -10,7 +10,7 @@ export header, Header,
     PointVariableBlockHeader,
     PlainMeshBlockHeader,
     PointMeshBlockHeader,
-    SDFVariable, SDFMesh
+    DiskArrayVariable, DiskArrayMesh,
 
 using Unitful: uparse
 using DiskArrays: DiskArrays, AbstractDiskArray, Chunked

--- a/src/mmap.jl
+++ b/src/mmap.jl
@@ -1,0 +1,69 @@
+abstract type AbstractMmapedEntry{T,N} <: AbstractArray{T,N} end
+
+struct MmapedVariable{T,N,B<:AbstractBlockHeader{T,N},I,M} <: AbstractMmapedEntry{T,N}
+    block::B
+    chunksize::NTuple{N,Int}
+    io::I
+    mm::M
+end
+
+auto_kernel_size(::AbstractBlockHeader{T,1}) where {T} = (100,)
+auto_kernel_size(::AbstractBlockHeader{T,2}) where {T} = (50, 50)
+auto_kernel_size(::AbstractBlockHeader{T,3}) where {T} = (20, 20, 20)
+
+function MmapedVariable(
+    file::IO,
+    block::Union{PlainVariableBlockHeader,PointVariableBlockHeader},
+    kernel_size=auto_kernel_size(block)
+)
+
+    dims = Int.(size(block))
+    n = prod(dims) * sizeof(eltype(block))
+    offset = get_offset(block)
+    chunksize = padded_tilesize(Float64, kernel_size)
+
+    mm = mmap(file, Vector{UInt8}, n, offset)
+    restored_type_mm = reinterpret(eltype(block), mm)
+    reshapd_mm = reshape(restored_type_mm, dims)
+
+    MmapedVariable(block, chunksize, file, reshapd_mm)
+end
+
+# PlainMeshBlockHeader is the mesh given by the "grid" block (the grid for fields),
+# there's no need to mmap it, we can just represtent it with a range
+
+struct MmapedParticleMesh{T,N,B<:PointMeshBlockHeader{T,N},I,M} <: AbstractMmapedEntry{T,1}
+    block::B
+    chunksize::Tuple{Int}
+    axis::Int
+    io::I
+    mm::M
+end
+
+Base.size(pm::MmapedParticleMesh) = (size(pm.block, pm.axis),)
+
+function MmapedParticleMesh(file::IO, block::PointMeshBlockHeader, axis::Int, kernel_size=(1000,))
+    dims = Int(size(block, axis))
+    n = dims * sizeof(eltype(block))
+    offset = get_offset(block, axis)
+    chunksize = padded_tilesize(Float64, kernel_size)
+
+    mm = mmap(file, Vector{UInt8}, n, offset)
+    restored_type_mm = reinterpret(eltype(block), mm)
+
+    MmapedParticleMesh(block, chunksize, axis, file, restored_type_mm)
+end
+
+# AbstractArray interface
+Base.size(ame::AbstractMmapedEntry) = size(ame.block)
+Base.IndexStyle(::Type{<:AbstractMmapedEntry}) = IndexLinear()
+Base.@propagate_inbounds Base.getindex(ame::AbstractMmapedEntry, i::Int) = ame.mm[i]
+
+# TiledIteration
+TiledIteration.TileIterator(ame::AbstractMmapedEntry) = TileIterator(axes(ame), ame.chunksize)
+TiledIteration.SplitAxis(ame::AbstractMmapedEntry, d) = SplitAxis(axes(ame, d), ame.chunksize[d])
+
+mmap_block(file::IO, block::Union{PlainVariableBlockHeader,PointVariableBlockHeader}, ks=auto_kernel_size(block)) = MmapedVariable(file, block, ks)
+mmap_block(file::IO, block::PointMeshBlockHeader, ax, ks=(1000,)) = MmapedParticleMesh(file, block, ax, ks)
+mmap_block(::IO, ::PlainMeshBlockHeader, args...) = error("There is no need to mmap this block type.")
+mmap_block(args...) = error("Unknown block type")

--- a/src/read_chunk.jl
+++ b/src/read_chunk.jl
@@ -69,7 +69,7 @@ function DiskArrays.readblock!(a::DiskArrayVariable, aout, idxs::AbstractUnitRan
     readchunk!(stream, aout, linear_idxs, eltype(block), offset)
 end
 
-function DiskArrays.readblock!(a::DiskArrayMesh, aout, idxs::AbstractUnitRange)
+function DiskArrays.readblock!(a::DiskArrayMesh{T}, aout, idxs::AbstractUnitRange) where T
     stream, block = a.stream, a.block
     axis = a.axis
     offset = get_offset(block, axis)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -8,6 +8,8 @@ labels(block::PointMeshBlockHeader) = block.labels
 labels(block::PlainMeshBlockHeader) = block.labels
 
 get_offset(block::AbstractBlockHeader) = block.base_header.data_location
+get_offset(block::PointMeshBlockHeader{T}, axis::Int) where {T} = get_offset(block) + sizeof(T) * block.np * (axis - 1)
+get_offset(block::PlainMeshBlockHeader{T}, axis::Int) where {T} = get_offset(block) + sizeof(T) * block.dims[axis] * (axis - 1)
 
 function add_units(raw_data::NTuple, block)
     𝟙 = one(eltype(block))

--- a/test/chunks.jl
+++ b/test/chunks.jl
@@ -13,11 +13,11 @@ unsupported = Symbol.(["cpu/proton", "cpu/electron", "run_info", "cpu_rank", "el
 meshes = Symbol.(["grid", "grid/electron", "grid/proton"])
 variables = setdiff(keys(blocks), unsupported, meshes)
 
-@testset "SDFVariable" begin
+@testset "DiskArrayVariable" begin
     open(fn, "r") do f
         @testset "$key" for key in variables
             block = blocks[key]
-            sda = SDFVariable(f, block)
+            sda = DiskArrayVariable(f, block)
             data = read!(f, block)
 
             @test haschunks(sda) isa Chunked
@@ -32,12 +32,12 @@ variables = setdiff(keys(blocks), unsupported, meshes)
     end
 end
 
-@testset "SDFMesh" begin
+@testset "DiskArrayMesh" begin
     open(fn, "r") do f
         @testset "$key" for key in meshes
             block = blocks[key]
             @testset "$key with axis $axis" for axis in 1:3
-                sda = SDFMesh(f, block, axis)
+                sda = DiskArrayMesh(f, block, axis)
                 data = read!(f, block)[axis]
 
                 @test haschunks(sda) isa Chunked

--- a/test/chunks.jl
+++ b/test/chunks.jl
@@ -8,9 +8,9 @@ ref_fn = joinpath(@__DIR__, "0002.jls")
 v_header, data, grids, units = open(deserialize, ref_fn)
 
 blocks = file_summary(fn)
-unsupported = Symbol.(["cpu/proton", "cpu/electron", "run_info", "cpu_rank", "elapsed_time"])
+unsupported = ["cpu/proton", "cpu/electron", "run_info", "cpu_rank", "elapsed_time"]
 
-meshes = Symbol.(["grid", "grid/electron", "grid/proton"])
+meshes = ["grid", "grid/electron", "grid/proton"]
 variables = setdiff(keys(blocks), unsupported, meshes)
 
 @testset "DiskArrayVariable" begin

--- a/test/mmap.jl
+++ b/test/mmap.jl
@@ -1,0 +1,49 @@
+using SDFReader
+using Serialization
+using Test
+
+fn = joinpath(@__DIR__, "0002.sdf")
+ref_fn = joinpath(@__DIR__, "0002.jls")
+v_header, data, grids, units = open(deserialize, ref_fn)
+
+blocks = file_summary(fn)
+unsupported = ["cpu/proton", "cpu/electron", "run_info", "cpu_rank", "elapsed_time"]
+
+meshes = ["grid/electron", "grid/proton"]
+variables = setdiff(keys(blocks), unsupported, meshes)
+
+@testset "MmapedVariable" begin
+    open(fn, "r") do f
+        @testset "$key" for key in variables
+            block = blocks[key]
+            sda = MmapedVariable(f, block)
+            data = read!(f, block)
+
+            @test sda[1, 1, 1] == data[1, 1, 1]
+            @test sda[2, 1, 1] == data[2, 1, 1]
+            @test sda[1:10, 1, 1] == data[1:10, 1, 1]
+            @test sda[15:20] == data[15:20]
+            @test sda[:, 1, 1] == data[:, 1, 1]
+            @test sda[:] == vec(data)
+        end
+    end
+end
+
+@testset "MmapedParticleMesh" begin
+    open(fn, "r") do f
+        @testset "$key" for key in meshes
+            block = blocks[key]
+            @testset "$key with axis $axis" for axis in 1:3
+                sda = MmapedParticleMesh(f, block, axis)
+                data = read!(f, block)[axis]
+
+                @test sda[1] == data[1]
+                @test sda[2:3] == data[2:3]
+                @test sda[1:5] == data[1:5]
+                @test sda[5:end] == data[5:end]
+                @test sda[begin:end] == data[begin:end]
+                @test sda[:] == data[:]
+            end
+        end
+    end
+end

--- a/test/mmap.jl
+++ b/test/mmap.jl
@@ -7,7 +7,7 @@ ref_fn = joinpath(@__DIR__, "0002.jls")
 v_header, data, grids, units = open(deserialize, ref_fn)
 
 blocks = file_summary(fn)
-unsupported = ["cpu/proton", "cpu/electron", "run_info", "cpu_rank", "elapsed_time"]
+unsupported = ["cpu/proton", "cpu/electron", "run_info", "cpu_rank", "elapsed_time", "grid"]
 
 meshes = ["grid/electron", "grid/proton"]
 variables = setdiff(keys(blocks), unsupported, meshes)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,4 +5,5 @@ using SafeTestsets
     @safetestset "SDF header" begin include("sdf_header.jl") end
     @safetestset "SDF data" begin include("sdf.jl") end
     @safetestset "DiskArrays integration" begin include("chunks.jl") end
+    @safetestset "mmap" begin include("mmap.jl") end
 end

--- a/test/sdf.jl
+++ b/test/sdf.jl
@@ -18,7 +18,7 @@ v_header, data, grids, units = open(deserialize, ref_fn)
         end
     end
 
-    unsupported = Symbol.(["cpu/proton", "cpu/electron", "run_info", "cpu_rank"])
+    unsupported = ["cpu/proton", "cpu/electron", "run_info", "cpu_rank"]
     @testset "Data" begin
         open(fn, "r") do f
             @testset "$key" for (key, block) in pairs(blocks)
@@ -30,9 +30,9 @@ v_header, data, grids, units = open(deserialize, ref_fn)
     end
 
     @testset "Utilities" begin
-        @test nameof(blocks[:ex]) == "Electric Field/Ex"
-        @test labels(blocks[:grid]) == ("X", "Y", "Z")
-        @test labels(blocks[Symbol("grid/electron")]) == ("X", "Y", "Z")
+        @test nameof(blocks["ex"]) == "Electric Field/Ex"
+        @test labels(blocks["grid"]) == ("X", "Y", "Z")
+        @test labels(blocks["grid/electron"]) == ("X", "Y", "Z")
     end
 
     @testset "Cache" begin
@@ -41,15 +41,15 @@ v_header, data, grids, units = open(deserialize, ref_fn)
             t1 = 0.
             t2 = 0.
             @testset "store" begin
-                ex = @timed cached_read(f, blocks[:ex], cache)
-                @test read(f, blocks[:ex]) == ex.value
+                ex = @timed cached_read(f, blocks["ex"], cache)
+                @test read(f, blocks["ex"]) == ex.value
                 t1 = ex.time
-                @test read(f, blocks[:ey]) == cached_read(f, blocks[:ey], cache)
+                @test read(f, blocks["ey"]) == cached_read(f, blocks["ey"], cache)
             end
             @testset "load" begin
-                ex = @timed cached_read(f, blocks[:ex], cache)
-                @test read(f, blocks[:ex]) == ex.value
-                @test read(f, blocks[:ey]) == cached_read(f, blocks[:ey], cache)
+                ex = @timed cached_read(f, blocks["ex"], cache)
+                @test read(f, blocks["ex"]) == ex.value
+                @test read(f, blocks["ey"]) == cached_read(f, blocks["ey"], cache)
                 t2 = ex.time
                 # test that the cache was used
                 @test t2 < 100t1


### PR DESCRIPTION
This adds `MmapedVariable` and `MmapedParticleMesh`, which memory map the underlying SDF blocks.

`MmapedVariable` is used for `PlainVariableBlockHeader` & `PointVariableBlockHeader` and will provide a reshaped array matching the block size.

`MmapedParticleMesh` is used for `PointMeshBlockHeader` and it also needs the user to supply the axis, as the blocks contain the data for all axes.

Since `PlainMeshBlockHeader` is the mesh given by the "grid" block (the grid for fields), there's no need to mmap it, we can just represtent it with a range.

This PR also introduces a breaking change in the represontation of blocks, we now use dictionaries with strings instead of symbols, as there was no advantage of using symbols and we were always converting stings to symbols.